### PR TITLE
Bugfix

### DIFF
--- a/MultilingualTrait.php
+++ b/MultilingualTrait.php
@@ -27,7 +27,7 @@ trait MultilingualTrait
             $language = Yii::$app->language;
 
         $this->with(['translation' => function ($query) use ($language) {
-            $query->andWhere([$this->languageField => substr($language, 0, 2)]);
+            $query->where([$this->languageField => substr($language, 0, 2)]);
         }]);
         return $this;
     }


### PR DESCRIPTION
I use Yii v2.0.1 and encountered the following bug:
Suppose we have configured 2 languages: 'uk' and 'ru'. Default app lang is 'uk'. 
I tried to get localized version in non-default lang like this:

``` php
$model = ModelClass::find()->localized('ru')->one();
echo $model->title; // It echoes title in default language, not 'ru'!
```

I found out that relational query condition value was ['and', ['language'=>'uk'], ['language'=>'ru']] that is, default app laguage (applied in MultilingualBehavior::getTranslation()) was and'd with scope's (MultilingualTrait::localized()) supplied parameter.

Simple fix for this misbehavior attached.
