### PR TITLE
Allow configuration of owners primary key

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ langClassName | The name of translation model class. Dafault value is model name
 **languages** | Available languages. It can be a simple array: ```['fr', 'en']``` or an associative array: ```['fr' => 'Français', 'en' => 'English']```
 **defaultLanguage** | The default language
 **langForeignKey** | Name of the foreign key field of the translation table related to base model table.
+**ownerPrimaryKey** | Name of the  primary key field in the ownser table. Defaults to the primary key of the owner model.
 **tableName** | The name of the translation table
 **attributes** | Multilingual attributes
 

--- a/src/MultilingualBehavior.php
+++ b/src/MultilingualBehavior.php
@@ -363,7 +363,7 @@ class MultilingualBehavior extends Behavior
                 /** @var ActiveRecord $translation */
                 $translation = new $this->langClassName;
                 $translation->{$this->languageField} = $lang;
-                $translation->{$this->langForeignKey} = $owner->getPrimaryKey();
+                $translation->{$this->langForeignKey} = $owner->getAttribute($this->ownerPrimaryKey);
             } else {
                 $translation = $translations[$lang];
             }

--- a/src/MultilingualBehavior.php
+++ b/src/MultilingualBehavior.php
@@ -87,9 +87,13 @@ class MultilingualBehavior extends Behavior
      */
     public $abridge = true;
 
+    /**
+     * @var string the name of the primary key field of the base model. Defaults to first value of Model::primaryKey.
+     */
+    public $ownerPrimaryKey;
+
     private $currentLanguage;
     private $ownerClassName;
-    private $ownerPrimaryKey;
     private $langClassShortName;
     private $ownerClassShortName;
     private $langAttributes = [];
@@ -160,7 +164,9 @@ class MultilingualBehavior extends Behavior
 
         /** @var ActiveRecord $className */
         $className = $this->ownerClassName;
-        $this->ownerPrimaryKey = $className::primaryKey()[0];
+        if (!isset($this->ownerPrimaryKey)) {
+            $this->ownerPrimaryKey = $className::primaryKey()[0];
+        }
 
         if (!isset($this->langForeignKey)) {
             throw new InvalidConfigException('Please specify langForeignKey for the ' . get_class($this) . ' in the '


### PR DESCRIPTION
Currently the primary key attribute is always the primary key of the owner object. Normally this is the only logic thing. But my illogical database structure, which I have to keep backwards compatible, wants to link on a different value. I've added the option to manually set the primary key field. Without configuration, the system works as normal, by defaulting to the owner model's primary key.